### PR TITLE
add multi-column-editor to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "contao/core-bundle": "^4.1",
     "box/spout": "^2.7",
     "heimrichhannot/contao-field-value-copier-bundle": "^1.1",
-    "heimrichhannot/contao-request-bundle": "^1.0"
+    "heimrichhannot/contao-request-bundle": "^1.0",
+    "heimrichhannot/contao-multi-column-editor-bundle": "^2.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This extension requires the `multiColumnEditor` widget in the `tl_exporter` DCA for two fields: `headerFieldLabels` and `joinTables`. Without it, those fields will not work.