### PR TITLE
Add a join-type option to Exporter-DCA.

### DIFF
--- a/src/EventListener/DataContainer/ExporterListener.php
+++ b/src/EventListener/DataContainer/ExporterListener.php
@@ -194,7 +194,17 @@ class ExporterListener
     {
         return Database::getInstance()->listTables();
     }
-    
+
+    /**
+     * Get available join options
+     *
+     * @return array
+     */
+    public function getAllJoinTypes()
+    {
+        return array('INNER JOIN', 'LEFT OUTER JOIN', 'RIGHT OUTER JOIN');
+    }
+
     /**
      * Searches through all backend modules to find global operation keys and returns a filtered list
      *

--- a/src/Exporter/AbstractExporter.php
+++ b/src/Exporter/AbstractExporter.php
@@ -78,7 +78,7 @@ abstract class AbstractExporter implements ExporterInterface
         $this->framework     = $framework;
         $this->dispatcher    = $dispatcher;
     }
-    
+
     public static function getAlias() {
         return str_replace('\\', '_', static::class);
     }
@@ -239,7 +239,7 @@ abstract class AbstractExporter implements ExporterInterface
             {
                 continue;
             }
-            
+
             if (strpos($field, static::EXPORTER_RAW_FIELD_SUFFIX) !== false)
             {
                 $exportFields[] = str_replace(EXPORTER_RAW_FIELD_SUFFIX, '', $field) . ' AS "' . $field . '"';
@@ -300,7 +300,7 @@ abstract class AbstractExporter implements ExporterInterface
         {
             foreach ($joinTables as $joinT)
             {
-                $query .= ' INNER JOIN ' . $joinT['joinTable'] . ' ON ' . $joinT['joinCondition'];
+                $query .= ' ' . $joinT['joinType'] . ' ' . $joinT['joinTable'] . ' ON ' . $joinT['joinCondition'];
             }
         }
 

--- a/src/Exporter/AbstractExporter.php
+++ b/src/Exporter/AbstractExporter.php
@@ -300,7 +300,13 @@ abstract class AbstractExporter implements ExporterInterface
         {
             foreach ($joinTables as $joinT)
             {
-                $query .= ' ' . $joinT['joinType'] . ' ' . $joinT['joinTable'] . ' ON ' . $joinT['joinCondition'];
+                if (!$joinT['joinType']) {
+                    $joinType = 'JOIN';
+                } else {
+                    $joinType = $joinT['joinType'];
+                }
+
+                $query .= ' ' . $joinType . ' ' . $joinT['joinTable'] . ' ON ' . $joinT['joinCondition'];
             }
         }
 

--- a/src/Resources/contao/dca/tl_exporter.php
+++ b/src/Resources/contao/dca/tl_exporter.php
@@ -512,6 +512,18 @@ $GLOBALS['TL_DCA']['tl_exporter'] = [
                                 'submitOnChange'     => true
                             ],
                         ],
+                        'joinType'     => [
+                            'label'            => &$GLOBALS['TL_LANG']['tl_exporter']['joinType'],
+                            'inputType'        => 'select',
+                            'options_callback' => ['huh.exporter.listener.dc.exporter', 'getAllJoinTypes'],
+                            'eval'             => [
+                                'chosen'             => true,
+                                'mandatory'          => true,
+                                'includeBlankOption' => false,
+                                'groupStyle'         => 'width: 250px',
+                                'style'              => 'width: 250px'
+                            ],
+                        ],
                         'joinCondition' => [
                             'label'     => &$GLOBALS['TL_LANG']['tl_exporter']['joinCondition'],
                             'inputType' => 'text',

--- a/src/Resources/contao/languages/de/tl_exporter.php
+++ b/src/Resources/contao/languages/de/tl_exporter.php
@@ -20,6 +20,7 @@ $arrLang['localizeFields'] = ['Feldwerte lokalisieren', 'Wählen Sie diese Optio
 $arrLang['addJoinTables'] = ['Join hinzufügen', 'Wählen Sie diese Option, wenn die verknüpfte Tabelle mit einer oder mehreren anderen Tabellen vereint werden soll.'];
 $arrLang['joinTables'] = ['Join-Elemente (ACHTUNG: Felder der gejointen Tabellen werden erst nach dem Speichern auswählbar)', ''];
 $arrLang['joinTable'] = ['Tabelle', 'Wählen Sie die Tabelle aus, die mit der verknüpften Tabelle vereint werden soll. '];
+$arrLang['joinType'] = ['JOIN-Typ', 'Wählen Sie den Typ des auszuführenden Joins aus.'];
 $arrLang['joinCondition'] = ['ON-Bedingung', 'Geben Sie hier Bedingungen für die ON-Klausel in der Form "Verknüpfte-Tabelle.Wert = Join-Tabelle.Wert" ein.'];
 $arrLang['addUnformattedFields'] = ['Unformatierte Felder nutzen', 'Wählen Sie diese Option, wenn Felder in unformatierter Form exportierbar sein sollen.'];
 $arrLang['whereClause'] = ['WHERE-Bedingung', 'Geben Sie hier eine WHERE-Bedingung in der Form column=X an. Bei Join-Abfragen muss die Eingabe in der Form table.column=X erweitert werden. Zeit-Bedingungen müssen als timestamp angegeben werden.'];

--- a/src/Resources/contao/languages/en/tl_exporter.php
+++ b/src/Resources/contao/languages/en/tl_exporter.php
@@ -19,6 +19,7 @@ $arrLang['localizeFields'] = ['Localize field values', 'Choose this option if fi
 $arrLang['addJoinTables'] = ['Add join', 'Choose this option if the linked table should be joined with some other table.'];
 $arrLang['joinTables'] = ['Join elements', ''];
 $arrLang['joinTable'] = ['Join table', 'Choose the table to be joined with the linked table.'];
+$arrLang['joinType'] = ['Join type', 'Choose the type of the join.'];
 $arrLang['joinCondition'] = ['ON condition', 'Please type in conditions for the ON clause in the form "linked_table.field = jin_table.field".'];
 $arrLang['addUnformattedFields'] = ['Use unformatted fields', 'Choose this option if you want to have unformatted fields in your export.'];
 $arrLang['whereClause'] = ['WHERE condition', 'Please type in a WHERE condition in the form column=X. In case of join the input needs to be extended in the form table.column=X. Temporal conditions need to be defined as timestamps.'];


### PR DESCRIPTION
When using the exporter on tables with child tables, one might need the LEFT JOIN-option to also export parent elements with no children. This change adds such an option to the tl_exporter, allowing the user to choose between INNER JOIN, LEFT OUTER JOIN and RIGHT OUTER JOIN.