### PR TITLE
Add missing variable

### DIFF
--- a/src/FrontendModule/ModuleFrontendExporter.php
+++ b/src/FrontendModule/ModuleFrontendExporter.php
@@ -73,7 +73,7 @@ class ModuleFrontendExporter extends Module
         {
             $frontendAction = new FrontendExportAction($this->container);
             $frontendAction->export($this->config);
-        } catch (\Exception)
+        } catch (\Exception $e)
         {
             Message::addError($this->container->get('translator')->trans('huh.exporter.error.exportNotPossible'), 'huh_exporter.frontend');
         }


### PR DESCRIPTION
The `composer.json` of the current version still allows PHP 7.4. However, the current version also has code in it that is only compatible with PHP 8 - e.g.:

```
ParseError:
syntax error, unexpected ')', expecting '|' or variable (T_VARIABLE)

  at vendor\heimrichhannot\contao-exporter-bundle\src\FrontendModule\ModuleFrontendExporter.php:76
```

(https://wiki.php.net/rfc/non-capturing_catches)